### PR TITLE
Remove https://garlicinsight.com link for anonymous pools

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -131,7 +131,7 @@
 	]
 }, {
 	"poolName": "Anonymous Pool",
-	"url": "https://garlicinsight.com",
+	"url": "",
 	"searchStrings": [
 		"/nodeStratum/"
 	]


### PR DESCRIPTION
Removing a link to https://garlicinsight.com for anonymous pools. This domain is now serving spam.

On the UI side an empty URL is rendered as a link that will return you to the home page for this insight instance. 
Room for future improvement: We can add logic to the UI side to render empty/null URLs as plain text.